### PR TITLE
Optionally load and save sh coefficients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "super-splat",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "super-splat",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "license": "MIT",
             "devDependencies": {
                 "@playcanvas/eslint-config": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "super-splat",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "author": "PlayCanvas<support@playcanvas.com>",
     "homepage": "https://playcanvas.com",
     "description": "All the splat things",

--- a/src/editor-ops.ts
+++ b/src/editor-ops.ts
@@ -156,7 +156,7 @@ const convertPly = (splatData: SplatData, modelMat: Mat4) => {
         numSplats += opacity[i] !== deletedOpacity ? 1 : 0;
     }
 
-    const props = ['x', 'y', 'z', 'f_dc_0', 'f_dc_1', 'f_dc_2', 'opacity', 'scale_0', 'scale_1', 'scale_2', 'rot_0', 'rot_1', 'rot_2', 'rot_3'];
+    const props = splatData.vertexElement.properties.filter(p => p.storage).map(p => p.name);
     const header = (new TextEncoder()).encode(`ply\nformat binary_little_endian 1.0\nelement vertex ${numSplats}\n` + props.map(p => `property float ${p}`).join('\n') + `\nend_header\n`);
     const result = new Uint8Array(header.byteLength + numSplats * props.length * 4);
 
@@ -717,6 +717,10 @@ const registerEvents = (scene: Scene, editorUI: EditorUI) => {
             editHistory.add(new ResetEditOp(splatData));
         });
         updateColorData();
+    });
+
+    events.on('shData', (value: boolean) => {
+        scene.assetLoader.loadSHData = value;
     });
 
     const removeExtension = (filename: string) => {

--- a/src/style.scss
+++ b/src/style.scss
@@ -85,6 +85,10 @@ body {
     flex-grow: 1;
 }
 
+.control-element.pcui-boolean-input {
+    margin-top: 10px;
+}
+
 .active {
     color: white;
     background-color: #f60 !important;

--- a/src/ui/control-panel.ts
+++ b/src/ui/control-panel.ts
@@ -621,6 +621,31 @@ class ControlPanel extends Container {
         scenePanel.append(position);
         scenePanel.append(rotation);
 
+        // import
+        const importPanel = new Panel({
+            class: 'control-panel',
+            headerText: 'Import'
+        });
+
+        const shData = new Container({
+            class: 'control-parent'
+        });
+
+        const shDataLabel = new Label({
+            class: 'control-label',
+            text: 'SH data'
+        });
+
+        const shDataToggle = new BooleanInput({
+            class: 'control-element',
+            value: false
+        });
+
+        shData.append(shDataLabel);
+        shData.append(shDataToggle);
+
+        importPanel.append(shData);
+
         // export
         const exportPanel = new Panel({
             class: 'control-panel',
@@ -674,6 +699,7 @@ class ControlPanel extends Container {
         this.append(selectionPanel);
         this.append(modifyPanel);
         this.append(scenePanel);
+        this.append(importPanel);
         this.append(exportPanel);
         this.append(keyboardPanel);
 
@@ -826,6 +852,10 @@ class ControlPanel extends Container {
 
         resetButton.on('click', () => {
             this.events.fire('reset');
+        });
+
+        shDataToggle.on('change', (enabled: boolean) => {
+            this.events.fire('shData', enabled);
         });
 
         exportPlyButton.on('click', () => {


### PR DESCRIPTION
This PR adds an import option to enable loading and saving the scene spherical harmonic coefficients as follows:

<img width="279" alt="Screenshot 2023-11-09 at 14 41 39" src="https://github.com/playcanvas/super-splat/assets/11276292/b02f0fb6-dba7-4922-b8f0-6830bb552ad0">

NOTE: the spherical harmonic data is currently just _blind data_ - the lighting won't be rotated along with the rest of the scene. This support will come in a followup PR.