### PR TITLE
Load all ply data by default

### DIFF
--- a/src/asset-loader.ts
+++ b/src/asset-loader.ts
@@ -22,7 +22,7 @@ interface EnvLoadRequest {
 class AssetLoader {
     registry: AssetRegistry;
     defaultAnisotropy: number;
-    loadSHData = false;
+    loadAllData = true;
 
     constructor(registry: AssetRegistry, defaultAnisotropy?: number) {
         this.registry = registry;
@@ -48,7 +48,7 @@ class AssetLoader {
                     contents: loadRequest.contents
                 },
                 isPly ? { 
-                    elementFilter: this.loadSHData ? (name => true) : null
+                    elementFilter: this.loadAllData ? (() => true) : null
                 } : null,
                 {
                     image: {

--- a/src/editor-ops.ts
+++ b/src/editor-ops.ts
@@ -750,8 +750,8 @@ const registerEvents = (scene: Scene, editorUI: EditorUI) => {
         updateColorData();
     });
 
-    events.on('shData', (value: boolean) => {
-        scene.assetLoader.loadSHData = value;
+    events.on('allData', (value: boolean) => {
+        scene.assetLoader.loadAllData = value;
     });
 
     const removeExtension = (filename: string) => {

--- a/src/ui/control-panel.ts
+++ b/src/ui/control-panel.ts
@@ -567,7 +567,7 @@ class ControlPanel extends Container {
 
         const positionVector = new VectorInput({
             class: 'control-element-expand',
-            precision: 4,
+            precision: 2,
             dimensions: 3,
             value: [0, 0, 0],
             placeholder: ['X', 'Y', 'Z']
@@ -588,7 +588,7 @@ class ControlPanel extends Container {
 
         const rotationVector = new VectorInput({
             class: 'control-element-expand',
-            precision: 4,
+            precision: 2,
             dimensions: 3,
             value: [0, 0, 0],
             placeholder: ['X', 'Y', 'Z']
@@ -609,7 +609,7 @@ class ControlPanel extends Container {
 
         const scaleInput = new NumericInput({
             class: 'control-element-expand',
-            precision: 4,
+            precision: 2,
             value: 1
         });
 

--- a/src/ui/control-panel.ts
+++ b/src/ui/control-panel.ts
@@ -627,24 +627,24 @@ class ControlPanel extends Container {
             headerText: 'IMPORT'
         });
 
-        const shData = new Container({
+        const allData = new Container({
             class: 'control-parent'
         });
 
-        const shDataLabel = new Label({
+        const allDataLabel = new Label({
             class: 'control-label',
-            text: 'SH data'
+            text: 'Load all PLY data'
         });
 
-        const shDataToggle = new BooleanInput({
+        const allDataToggle = new BooleanInput({
             class: 'control-element',
-            value: false
+            value: true
         });
 
-        shData.append(shDataLabel);
-        shData.append(shDataToggle);
+        allData.append(allDataLabel);
+        allData.append(allDataToggle);
 
-        importPanel.append(shData);
+        importPanel.append(allData);
 
         // export
         const exportPanel = new Panel({
@@ -857,8 +857,8 @@ class ControlPanel extends Container {
             this.events.fire('reset');
         });
 
-        shDataToggle.on('change', (enabled: boolean) => {
-            this.events.fire('shData', enabled);
+        allDataToggle.on('change', (enabled: boolean) => {
+            this.events.fire('allData', enabled);
         });
 
         exportPlyButton.on('click', () => {


### PR DESCRIPTION
We can choose to load only the used subset of data from PLY files, thereby saving large amounts of browser memory.

This PR sets the default to load all data.